### PR TITLE
Fix: Cloud customers being displayed wrong

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -117,7 +117,7 @@ import SmallSponsors from "../components/SmallSponsors.svelte";
         class="text-neutral-400 sm:text-base text-xs sm:flex-row flex flex-col gap-1 pt-2 sm:justify-center"
       >
         <span class="text-warning mt-[0.1rem] font-bold font-mono"
-          >{2260}.toLocaleString()}+</span
+          >{(2260).toLocaleString()}+</span
         > customers in the cloud.
       </div>
     </div>


### PR DESCRIPTION
<img width="356" height="139" alt="image" src="https://github.com/user-attachments/assets/dfcd42ab-4bb0-46fc-bf29-f9704b479efe" />

(Prod for reference):
<img width="491" height="154" alt="image" src="https://github.com/user-attachments/assets/5c256e74-0432-445b-b683-cf40633b9143" />
