### PR TITLE
Fix broken homepage js

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -117,7 +117,7 @@ import SmallSponsors from "../components/SmallSponsors.svelte";
         class="text-neutral-400 sm:text-base text-xs sm:flex-row flex flex-col gap-1 pt-2 sm:justify-center"
       >
         <span class="text-warning mt-[0.1rem] font-bold font-mono"
-          >{2260}.toLocaleString()}+</span
+          >{{2260}.toLocaleString()}+</span
         > customers in the cloud.
       </div>
     </div>


### PR DESCRIPTION
This PR fixes the broken homepage JavaScript that currently looks like this:
<img width="430" height="61" alt="image" src="https://github.com/user-attachments/assets/174b8391-64ff-4696-b286-b47ba101ed9e" />
