### PR TITLE
Missing "sudo" before "bash"

### DIFF
--- a/src/pages/self-hosted.astro
+++ b/src/pages/self-hosted.astro
@@ -33,7 +33,7 @@ import Layout from "../layouts/Layout.astro";
       </div>
       <div>
         <span class="select-none text-neutral-500 font-extrabold pr-2">></span
-        >curl -fsSL https://cdn.coollabs.io/coolify/install.sh | bash
+        >curl -fsSL https://cdn.coollabs.io/coolify/install.sh | sudo bash
       </div>
     </div>
   </div>


### PR DESCRIPTION
While trying to install Coolify directly from the command shown in the main site, I ended up with an error.

A quick check on the documentation shows the correct command, with "sudo" preceding "bash".

This PR merely changes that line, so you can install directly from the main site.