### PR TITLE
fix(sponsors): hidden image due to adblocker

### DIFF
--- a/src/components/BigSponsors.svelte
+++ b/src/components/BigSponsors.svelte
@@ -407,11 +407,7 @@
         <div bind:this={hugeSponsorGridElement} class="huge-sponsors-grid pb-6">
             {#each hugeSponsorsWithRef as sponsor (sponsor.name)}
                 <div class="tooltip tooltip-top" data-tip={sponsor.description}>
-                    <a
-                        class="sponsor-card huge plausible-event-name=big-sponsor-clicks"
-                        href={sponsor.url}
-                        style={sponsor.hugeCardStyle}
-                    >
+                    <div class="sponsor-card huge" style={sponsor.hugeCardStyle}>
                         <div class="sponsor-image-container">
                             <img
                                 src={`/images/${sponsor.imageKey}`}
@@ -421,7 +417,12 @@
                                 style={sponsor.hugeImageStyle}
                             />
                         </div>
-                    </a>
+                    </div>
+                    <a
+                        class="sponsor-link-overlay plausible-event-name=big-sponsor-clicks"
+                        href={sponsor.url}
+                        aria-label={sponsor.name}
+                    ></a>
                 </div>
             {/each}
         </div>
@@ -431,11 +432,7 @@
     <div bind:this={sponsorsGridElement} class="sponsors-grid pb-10">
         {#each sponsorsWithRef as sponsor (sponsor.name)}
             <div class="tooltip tooltip-top" data-tip={sponsor.description}>
-                <a
-                    class="sponsor-card {sponsor.tier ||
-                        ''} plausible-event-name=big-sponsor-clicks"
-                    href={sponsor.url}
-                >
+                <div class="sponsor-card {sponsor.tier || ''}">
                     <div class="sponsor-content">
                         {#if sponsor.isSpecial}
                             <div class="bg-red-500">
@@ -467,7 +464,12 @@
                             </div>
                         {/if}
                     </div>
-                </a>
+                </div>
+                <a
+                    class="sponsor-link-overlay plausible-event-name=big-sponsor-clicks"
+                    href={sponsor.url}
+                    aria-label={sponsor.name}
+                ></a>
             </div>
         {/each}
     </div>
@@ -537,7 +539,23 @@
             0 0 0 1px rgba(167, 139, 250, 0.35);
     }
 
+    .tooltip:hover .sponsor-card.huge,
+    .tooltip:has(.sponsor-link-overlay:focus-visible) .sponsor-card.huge {
+        transform: translateY(-8px) scale(1.02);
+        border-color: #a78bfa;
+        border-style: solid;
+        box-shadow:
+            0 20px 25px -5px rgba(0, 0, 0, 0.3),
+            0 10px 10px -5px rgba(0, 0, 0, 0.1),
+            0 0 0 1px rgba(167, 139, 250, 0.35);
+    }
+
     .sponsor-card.huge:hover::before {
+        opacity: 1;
+    }
+
+    .tooltip:hover .sponsor-card.huge::before,
+    .tooltip:has(.sponsor-link-overlay:focus-visible) .sponsor-card.huge::before {
         opacity: 1;
     }
 
@@ -629,6 +647,18 @@
         min-height: 118px;
     }
 
+    .sponsor-link-overlay {
+        position: absolute;
+        inset: 0;
+        z-index: 10;
+        border-radius: 0.3rem;
+    }
+
+    .sponsor-link-overlay:focus-visible {
+        outline: 2px solid #a78bfa;
+        outline-offset: 3px;
+    }
+
     .sponsor-card::before {
         content: "";
         position: absolute;
@@ -672,7 +702,23 @@
             0 0 0 1px rgba(96, 165, 250, 0.2);
     }
 
+    .tooltip:hover .sponsor-card:not(.huge),
+    .tooltip:has(.sponsor-link-overlay:focus-visible) .sponsor-card:not(.huge) {
+        transform: translateY(-8px) scale(1.02);
+        border-color: #6b16ed;
+        border-style: solid;
+        box-shadow:
+            0 20px 25px -5px rgba(0, 0, 0, 0.3),
+            0 10px 10px -5px rgba(0, 0, 0, 0.1),
+            0 0 0 1px rgba(96, 165, 250, 0.2);
+    }
+
     .sponsor-card:hover:not(.huge)::before {
+        opacity: 1;
+    }
+
+    .tooltip:hover .sponsor-card:not(.huge)::before,
+    .tooltip:has(.sponsor-link-overlay:focus-visible) .sponsor-card:not(.huge)::before {
         opacity: 1;
     }
 
@@ -755,6 +801,12 @@
     }
 
     .sponsor-card:hover .sponsor-image {
+        transform: scale(1.1);
+        filter: brightness(1) contrast(1.2);
+    }
+
+    .tooltip:hover .sponsor-image,
+    .tooltip:has(.sponsor-link-overlay:focus-visible) .sponsor-image {
         transform: scale(1.1);
         filter: brightness(1) contrast(1.2);
     }

--- a/src/components/SmallSponsors.svelte
+++ b/src/components/SmallSponsors.svelte
@@ -385,17 +385,13 @@
         {#each smallSponsors as sponsor (sponsor.name)}
           <div class="embla-small__slide">
             {#if sponsor.isSpecial && sponsor.imageUrl === "question"}
-              <a
-                class="w-12 h-12 border border-warning font-bold border-dashed hover:bg-warning hover:text-black flex justify-center text-center items-center text-3xl text-white animate-pulse rounded-full plausible-event-name=small-sponsor-clicks"
-                href={sponsor.url}
+              <div
+                class="small-sponsor-visual w-12 h-12 border border-warning font-bold border-dashed hover:bg-warning hover:text-black flex justify-center text-center items-center text-3xl text-white animate-pulse rounded-full"
               >
                 ?!
-              </a>
+              </div>
             {:else if sponsor.isSpecial && sponsor.imageUrl === "runpod-svg"}
-              <a
-                href={sponsor.url}
-                class="plausible-event-name=small-sponsor-clicks"
-              >
+              <div class="small-sponsor-visual">
                 <svg
                   class="w-11 h-11 fill-[#824edc] bg-white rounded"
                   xmlns="http://www.w3.org/2000/svg"
@@ -411,12 +407,9 @@
                     />
                   </g>
                 </svg>
-              </a>
+              </div>
             {:else if sponsor.isPublicImage}
-              <a
-                href={sponsor.url}
-                class="plausible-event-name=small-sponsor-clicks"
-              >
+              <div class="small-sponsor-visual">
                 <img
                   class={sponsor.customStyle || ""}
                   src={sponsor.imageUrl}
@@ -425,11 +418,10 @@
                   loading="eager"
                   alt={sponsor.name}
                 />
-              </a>
+              </div>
             {:else}
-              <a
-                href={sponsor.url}
-                class="transition-all duration-100 hover:scale-110 plausible-event-name=small-sponsor-clicks {sponsor.newest
+              <div
+                class="small-sponsor-visual transition-all duration-100 {sponsor.newest
                   ? 'rainbow-border'
                   : ''}"
               >
@@ -441,8 +433,13 @@
                   loading="eager"
                   alt={sponsor.name}
                 />
-              </a>
+              </div>
             {/if}
+            <a
+              href={sponsor.url}
+              class="small-sponsor-link plausible-event-name=small-sponsor-clicks"
+              aria-label={sponsor.name}
+            ></a>
           </div>
         {/each}
       </div>
@@ -494,6 +491,35 @@
     user-select: none;
     -webkit-touch-callout: none;
     -webkit-tap-highlight-color: transparent;
+  }
+
+  .small-sponsor-visual {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .small-sponsor-link {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+  }
+
+  .small-sponsor-link:focus-visible {
+    outline: 2px solid #fcd34d;
+    outline-offset: 3px;
+    border-radius: 9999px;
+  }
+
+  .embla-small__slide:hover .small-sponsor-visual.transition-all,
+  .embla-small__slide:has(.small-sponsor-link:focus-visible)
+    .small-sponsor-visual.transition-all {
+    transform: scale(1.1);
+  }
+
+  .embla-small__slide:hover .small-sponsor-visual.border-warning {
+    background-color: var(--color-warning, #fcd34d);
+    color: #000;
   }
 
   .rainbow-border {


### PR DESCRIPTION
Ad blockers are targeting and hiding links in the sponsor lists. This naturally also hides the child image.
Instead of wrapping the link over the image, we can render the link next to the image and overlay it on top of the image again. This prevents the image from disappearing when the link gets blocked.