### PR TITLE
fix(navigation): prevent desktop header overlap

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1783415637454
+		"lastUpdateCheck": 1786346459804
 	}
 }

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -2,7 +2,7 @@
   class="sticky top-0 z-50 bg-[rgba(16,16,16,0.8)] backdrop-blur-[12px] border-b border-[rgba(36,36,36,0.5)]"
 >
   <nav class="max-w-[96rem] mx-auto px-4 flex items-center justify-between h-16">
-    <a href="/" class="flex items-center gap-2">
+    <a href="/" class="flex shrink-0 items-center gap-2">
       <img src="/android-launchericon-48-48.png" alt="Coolify" class="size-6" />
       <span class="text-xl block text-white font-bold tracking-tight"
         >Coolify</span
@@ -10,11 +10,11 @@
     </a>
     <button
       id="mobile-menu-button"
-      class="xl:hidden text-white p-2 rounded border-0 hover:bg-coolgray-200 transition-colors"
+      class="2xl:hidden text-white p-2 rounded border-0 hover:bg-coolgray-200 transition-colors"
     >
       <i class="ph-duotone ph-list text-white text-2xl" aria-hidden="true"></i>
     </button>
-    <div id="desktop-menu" class="hidden xl:flex items-center gap-1">
+    <div id="desktop-menu" class="hidden 2xl:flex items-center gap-2">
       <a class="navbar-link relative gap-4" href="/philosophy">
         <i class="ph-duotone ph-lightbulb text-warning text-xl" aria-hidden="true"></i>Philosophy</a
       >
@@ -62,7 +62,7 @@
       Community <span id="community-count" class="text-xs">(20k+)</span>
     </a>
       <a
-        class="p-2 px-4 rounded text-white border border-coollabs hover:bg-coollabs bg-coollabs/30 font-semibold"
+        class="ml-2 shrink-0 whitespace-nowrap p-2 px-4 rounded text-white border border-coollabs hover:bg-coollabs bg-coollabs/30 font-semibold"
         href="https://app.coolify.io"
       >
         To Cloud</a


### PR DESCRIPTION
## Summary

- Prevent desktop navigation links from crowding the "To Cloud" CTA.
- Improve header spacing and preserve the CTA and logo sizing.
- Use the mobile menu at narrower desktop widths for consistent alignment.

Fixes #78

---

Fixes #78